### PR TITLE
Added possibility to configure custom error processing middlewares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+## [1.4.0] 2018-03-12
+- added `error_processing_middlewares` opts to Blunder.Absinthe.add_error_handling
+
 ## [1.3.0] 2018-05-16
 - added opts to Blunder.Absinthe.add_error_handling
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Add Blunder error handling to your resolvers by letting Blunder wrap your middle
   end
 ```
 
+It is possible to add custom error handling middleware like:
+```elixir
+  def middleware(middleware, field, _object) do
+    Blunder.Absinthe.add_error_handling(middleware, field, error_processing_middlewares: [CustomErrorProcessingMiddleware])
+  end
+```
+
 This will catch all exceptions as well as provide special handling for any `%Blunder{}` errors returned from resolver functions.
 
 ### Start returning Blunder Errors

--- a/lib/blunder/absinthe.ex
+++ b/lib/blunder/absinthe.ex
@@ -29,7 +29,7 @@ defmodule Blunder.Absinthe do
     Enum.map(
       middleware,
       &add_error_handling(&1, field, opts)
-    ) ++ [Blunder.Absinthe.ErrorProcessingMiddleware]
+    ) ++ Keyword.get(opts, :error_processing_middlewares, []) ++ [Blunder.Absinthe.ErrorProcessingMiddleware]
   end
 
   def add_error_handling({Absinthe.Middleware.MapGet, attr} = spec, %{identifier: attr}, _opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Blunder.Absinthe.Mixfile do
     [
       app: :blunder_absinthe,
       name: "Blunder.Absinthe",
-      version: "1.3.0",
+      version: "1.4.0",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       start_permanent: Mix.env == :prod,


### PR DESCRIPTION
#### What does this PR do?
Added possibility to configure custom error processing middlewares.

#### Why?
Sometimes it is necessary to add custom common error handling. For example to handle ecto errors like:
```
  def call(resolution, _config) do
    errors = for error <- resolution.errors do
      case error do
        %Ecto.Changeset{} = changeset -> bad_request(summary: error_for(changeset))
        error -> error
      end
    end

    %{resolution | errors: errors}
  end

  def error_for(changeset) do
    changeset.errors
    |> Keyword.keys
    |> Enum.map(fn field ->
      {error, _} = Keyword.get(changeset.errors, field)
      "#{field} #{error}"
    end)
    |> Enum.join(",")
  end
```

#### Other Questions:
- [x] Did I run this locally?
- [x] Did I run the whole test suite?
- [x] Did I run `mix dialyzer`?
- [x] Did I add tests to cover the change?
- [ ] Any additional deploy/release considerations?
- [ ] Does this PR cause necessary updates to the FAQ / documentation?
